### PR TITLE
サービス稼働したままカラム追加などが可能なように、DOMA2002エラーを抑制する設定をConfigで行えるようにする。

### DIFF
--- a/doma/src/main/java/org/seasar/doma/internal/RuntimeConfig.java
+++ b/doma/src/main/java/org/seasar/doma/internal/RuntimeConfig.java
@@ -108,4 +108,9 @@ public class RuntimeConfig implements Config {
         return config.getBatchSize();
     }
 
+    @Override
+    public boolean ignoreUnknownColumn() {
+        return config.ignoreUnknownColumn();
+    }
+
 }

--- a/doma/src/main/java/org/seasar/doma/internal/jdbc/command/EntityBuilder.java
+++ b/doma/src/main/java/org/seasar/doma/internal/jdbc/command/EntityBuilder.java
@@ -118,10 +118,13 @@ public class EntityBuilder<E> {
                 if (ROWNUMBER_COLUMN_NAME.equals(lowerCaseColumnName)) {
                     continue;
                 }
-                throwMappedPropertyNotFoundException(columnName);
+                if (!query.getConfig().ignoreUnknownColumn()) {
+                    throwMappedPropertyNotFoundException(columnName);
+                }
+            } else {
+                unmappedPropertySet.remove(propertyType);
+                indexMap.put(i, propertyType);
             }
-            unmappedPropertySet.remove(propertyType);
-            indexMap.put(i, propertyType);
         }
         if (resultMappingEnsured && !unmappedPropertySet.isEmpty()) {
             throwResultMappingException(unmappedPropertySet);

--- a/doma/src/main/java/org/seasar/doma/jdbc/Config.java
+++ b/doma/src/main/java/org/seasar/doma/jdbc/Config.java
@@ -143,4 +143,10 @@ public interface Config {
      */
     int getBatchSize();
 
+    /**
+     * Entityに定義が存在しないカラムが結果セットに含まれていた場合に、無視するかどうかを示すフラグです。
+     * @return Entityに定義が存在しないカラムを無視するならば true, そうでなければ false.
+     */
+    boolean ignoreUnknownColumn();
+
 }

--- a/doma/src/main/java/org/seasar/doma/jdbc/DomaAbstractConfig.java
+++ b/doma/src/main/java/org/seasar/doma/jdbc/DomaAbstractConfig.java
@@ -108,4 +108,9 @@ public abstract class DomaAbstractConfig implements Config {
     public int getBatchSize() {
         return 10;
     }
+
+    @Override
+    public boolean ignoreUnknownColumn() {
+        return false;
+    }
 }

--- a/doma/src/test/java/org/seasar/doma/internal/jdbc/mock/MockConfig.java
+++ b/doma/src/test/java/org/seasar/doma/internal/jdbc/mock/MockConfig.java
@@ -110,6 +110,11 @@ public class MockConfig implements Config {
         return 10;
     }
 
+    @Override
+    public boolean ignoreUnknownColumn() {
+        return false;
+    }
+
     public MockDataSource getMockDataSource() {
         return dataSource;
     }


### PR DESCRIPTION
SQL ファイルにて SELECT \* FROM ... などとしていた場合、
DBのマイグレーションでカラム追加を行うと、DOMA2002エラーになってしまいます。

かといって、新しいアプリコードをリリースしてからDBのカラム追加を行うと、
リリースからカラム追加までサービスが動かなくなります。

全てのSQLファイルで \* の利用を止めるという方針もありますが、カラム追加のたびに
関連するEntityの全SQLファイルを修正するのはちょっと生産的とは思えません。

そこで、production の時だけでも DOMA2002エラー を抑制できるような設定を
Config クラスに追加するというのは如何でしょうか？

ご検討のほどよろしくお願いします。
